### PR TITLE
Allow Replacement of Tags in the success form even on redirect!

### DIFF
--- a/include/inc_front/content/cnt23.article.inc.php
+++ b/include/inc_front/content/cnt23.article.inc.php
@@ -1590,16 +1590,13 @@ if(!empty($POST_DO) && empty($POST_ERR)) {
 			// replace tags in email form
 			$cnt_form['template'] = str_replace('{'. $POST_key . '}', $POST_keyval, $cnt_form['template']);
 			
-			//replace tags in the success form but not for redirect.
-			if($cnt_form["onsuccess_redirect"] !== 1) {
-				
+			
 				// check if it is htmlentity
 				if(!$cnt_form['is_html_entity'] && $cnt_form["onsuccess_redirect"] === 2) {
 					$POST_keyval = html_specialchars($POST_keyval);
 				}
 				$cnt_form["onsuccess"] = str_replace('{'. $POST_key . '}', $POST_keyval, $cnt_form["onsuccess"]);
 				$cnt_form["onsuccess"] = render_cnt_template($cnt_form["onsuccess"], 'EMAIL_COPY', empty($cnt_form['sendcopy']) || $cnt_form['option_email_copy'] === false ? '' : html_specialchars($cnt_form["copyto"]));
-			}
 			
 		}
 		


### PR DESCRIPTION
This is critical if you want to use a CP Form as a search box. You can then for instance redirect to sth. like "search?searchstart=1&searchwords={search_input_field}". There is no reason not to replace tags if redirect is selected.
