### PR TITLE
Dateien aus dem Backend vom Server löschen

### DIFF
--- a/include/inc_act/act_delete_from_server.php
+++ b/include/inc_act/act_delete_from_server.php
@@ -1,0 +1,47 @@
+<?php
+session_start();
+$phpwcms = array();
+
+require_once '../../include/config/conf.inc.php';
+require_once '../inc_lib/default.inc.php';
+require_once PHPWCMS_ROOT.'/include/inc_lib/helper.session.php';
+require_once PHPWCMS_ROOT.'/include/inc_lib/dbcon.inc.php';
+require_once PHPWCMS_ROOT.'/include/inc_lib/general.inc.php';
+checkLogin();
+validate_csrf_tokens();
+require_once PHPWCMS_ROOT.'/include/inc_lib/backend.functions.inc.php';
+
+//Starte Funktion nur wenn User => Admin
+if($_SESSION["wcs_user_admin"] == 1) {
+//User ist Admin und klickt "Dateien vom Sever löschen"
+if(isset($_GET['deletedeletedfiles']) && intval($_GET['deletedeletedfiles']) == $_SESSION["wcs_user_id"]) {
+	
+//Funktion startet	
+function deleteFilesFromDirectory($deldir){
+//Existiert das Verzeichnis?
+if (is_dir($deldir)) {
+//Verzeichnisrechte auf 0777 setzen	
+@mkdir ($deldir, 0777);		
+//Verzeichnis öffnen
+if ($dir = opendir($deldir)) {
+//Alle Files auslesen
+while (($file = readdir($dir)) !== false) {
+//Standartverzeichnisse beim auslesen ignorieren
+if ($file!="." AND $file !="..") {
+//Files vom Server löschen
+unlink("".$deldir."".$file."");
+}
+} 
+}
+//geöffnetes Verzeichnis wieder schließen
+closedir($dir);
+}
+}
+}
+}
+
+//Funktionsaufruf - Directory immer mit endendem / angeben
+deleteFilesFromDirectory(PHPWCMS_ROOT.'/filearchive/can_be_deleted/');
+$ref = empty($_SESSION['REFERER_URL']) ? PHPWCMS_URL.'phpwcms.php?'.get_token_get_string('csrftoken') : $_SESSION['REFERER_URL'];
+headerRedirect($ref);
+?>

--- a/include/inc_lang/backend/de/lang.inc.php
+++ b/include/inc_lang/backend/de/lang.inc.php
@@ -1399,3 +1399,7 @@ $BL['be_fsearch_nor'] = 'KEINES';
 $BL['be_tab_toggle'] = 'Reiter aus- bzw. einklappen';
 $BL['be_custom_textfield'] = 'Freitext';
 $BL['be_tab_template_toggle_warning'] = 'Wenn Sie die Vorlage umstellen, kann passieren, dass sich die Freitextfelder ändern und Werte verloren gehen.\n\nMöchten Sie wirklich fortfahren?';
+
+//Added by Uwe 367 29.01.2016
+$BL['be_cnt_delete_from_server'] = 'Dateien vom Server l&ouml;schen';
+$BL['be_cnt_delete_from_server_msg'] = 'Sollen wirklich alle Dateien, die sich\nim L&ouml;schordner befinden, eng&uuml;ltig\nvom Server gel&ouml;scht werden?';

--- a/include/inc_lang/backend/en/lang.inc.php
+++ b/include/inc_lang/backend/en/lang.inc.php
@@ -1409,3 +1409,6 @@ $BL['be_tab_toggle'] = 'Toggle tab to expanded or closed';
 $BL['be_custom_textfield'] = 'custom text';
 $BL['be_tab_template_toggle_warning'] = 'Changing the template can have the effect that custom fields get changed too and existing values get lost.\n\nAre you really sure to continue?';
 
+//Added by Uwe 367 29.01.2016
+$BL['be_cnt_delete_from_server'] = 'Delete files from Server';
+$BL['be_cnt_delete_from_server_msg'] = 'Do you really want to delete all\nfiles in the deletion folder from the Server?';

--- a/include/inc_lib/helper.session.php
+++ b/include/inc_lib/helper.session.php
@@ -400,6 +400,7 @@ function tokenize_urls($html) {
 			'/act_frontendsetup.php?',
 			'/act_message.php?',
 			'/act_cache.php?'
+			'/act_delete_from_server.php?'
 		);
 
 		$replace = array(
@@ -414,6 +415,7 @@ function tokenize_urls($html) {
 			'/act_frontendsetup.php?'.$get_token.'&amp;',
 			'/act_message.php?'.$get_token.'&amp;',
 			'/act_cache.php?'.$get_token.'&amp;'
+			'/act_delete_from_server.php?'.$get_token.'&amp;'
 		);
 
 		$html = str_replace($search, $replace, $html);

--- a/include/inc_lib/helper.session.php
+++ b/include/inc_lib/helper.session.php
@@ -399,7 +399,7 @@ function tokenize_urls($html) {
 			'/act_user.php?',
 			'/act_frontendsetup.php?',
 			'/act_message.php?',
-			'/act_cache.php?'
+			'/act_cache.php?',
 			'/act_delete_from_server.php?'
 		);
 
@@ -414,7 +414,7 @@ function tokenize_urls($html) {
 			'/act_user.php?'.$get_token.'&amp;',
 			'/act_frontendsetup.php?'.$get_token.'&amp;',
 			'/act_message.php?'.$get_token.'&amp;',
-			'/act_cache.php?'.$get_token.'&amp;'
+			'/act_cache.php?'.$get_token.'&amp;',
 			'/act_delete_from_server.php?'.$get_token.'&amp;'
 		);
 

--- a/phpwcms.php
+++ b/phpwcms.php
@@ -187,6 +187,9 @@ switch ($do) {
 							$subnav .= '<tr><td colspan="2"><img src="img/leer.gif" height="5" width="1" alt="" /></td></tr>'."\n";
 							$subnav .= subnavtext($BL['be_flush_image_cache'], '#', 1, 0, 0, 'onclick="return flush_image_cache(this,\'include/inc_act/ajax_connector.php?action=flush_image_cache&value=1\');" ');
 							$subnav .= subnavtext($BL['be_cnt_move_deleted'], 'include/inc_act/act_file.php?movedeletedfiles='. $_SESSION["wcs_user_id"], 1, 0, 0, 'onclick="return confirm(\''.$BL['be_cnt_move_deleted_msg'].'\');" ');
+							//--- Edit by Uwe367 29.01.2016 ---
+							$subnav .= subnavtext($BL['be_cnt_delete_from_server'], 'include/inc_act/act_delete_from_server.php?deletedeletedfiles='. $_SESSION["wcs_user_id"], 1, 0, 0, 'onclick="return confirm(\''.$BL['be_cnt_delete_from_server_msg'].'\');" ');
+							//--- /Edit ---
 							$subnav .= '<tr><td colspan="2"><img src="img/leer.gif" height="5" width="1" alt="" /></td></tr>'."\n";
 							$subnav .= subnavtextext('phpinfo()', 'include/inc_act/act_phpinfo.php', '_blank', 0);
 						}
@@ -297,8 +300,9 @@ if($BE['LANG'] == 'ar') {
 		?>
 		<form action="phpwcms.php" method="POST" class="backend-search">
 
-			<h1 class="title" style="margin:0 0 3px 0;"><?php echo $BL['be_ctype_search'] ?></h1>
-			<input type="search" name="backend_search_input" value="<?php
+			<!-- Edit by Uwe 367 Backend Search with Placeholder instead of heading-->
+			<!--<h1 class="title" style="margin:0 0 3px 0;"><?php //echo $BL['be_ctype_search'] ?></h1>-->
+			<input type="search" name="backend_search_input" value=""placeholder="<?php echo $BL['be_ctype_search'] ?>"<?php
 
 				if(isset($_POST['backend_search_input'])) {
 					$_SESSION['phpwcms_backend_search'] = clean_slweg($_POST['backend_search_input']);


### PR DESCRIPTION
Eine Möglichkeit Dateien, die im Verzeichnis **can_be_deleted** liegen, mittels Klick aus dem Backend vom Server zu löschen. Hierzu wird im Backend unter dem Menüpunkt ADMIN ein weiterer Link **Dateien vom Server löschen** unterhalb von **Dateien final löschen** hinzugefügt.
Die Reihenfolge beim Löschen von Dateien muß wie bisher eingehalten werden:
Datei in der Dateizentrale löschen, Papierkorb in der Dateizentrale leeren, dann Dateien final löschen und zuletzt Dateien vom Server löschen.

Vorteil:
Man benötigt keinen FTP Zugang um Dateien vom Server zu löschen. Gelegentlich müßen Dateien auch aus rechtlichen Gründen schnell vom Server entfernt werden. Auch hier ist der Vorteil ersichtlich denn es muß nicht gewartet werden bis jemand mittels FTP auf den Server zugreifen kann.

Feature getestet auf Localhost und Webspace bei all-inkl.
Derzeit verfügbar in den Sprachen DE und EN. Andere Sprachen können hinzugefügt werden.

Weiterhin habe ich in diesem Zuge die Backendsuche ein wenig verändert. Placeholder im Eingabefeld anstatt Überschrift. Moderner und platzsparend.