### PR TITLE
Possibility to use also URL of Caption Input

### DIFF
--- a/include/inc_front/content/cnt8.article.inc.php
+++ b/include/inc_front/content/cnt8.article.inc.php
@@ -688,6 +688,7 @@ if((is_array($content['alink']['alink_id']) && count($content['alink']['alink_id
                     $content['alink']['tr'][$key]   = render_cnt_template($content['alink']['tr'][$key], 'CAPTION_SUPPRESS', empty($row['article_image']['list_caption_suppress']) ? '' : ' ');
                     $content['alink']['tr'][$key]   = render_cnt_template($content['alink']['tr'][$key], 'CAPTION', $row['article_image']['list_caption']);
                     $content['alink']['tr'][$key]   = render_cnt_template($content['alink']['tr'][$key], 'CAPTION_ALT', $content['alink']['caption'][1]);
+                    $content['alink']['tr'][$key]   = render_cnt_template($content['alink']['tr'][$key], 'CAPTION_URL', $content['alink']['caption'][2][0]);
                     $content['alink']['tr'][$key]   = render_cnt_template($content['alink']['tr'][$key], 'CAPTION_TITLE', $content['alink']['caption'][3]);
 
                     // article class based on keyword *CSS-classname*


### PR DESCRIPTION
Right now it is only possible to use URL of Caption when also an image is used. Other 'Fields' of that Input can be used without using of image.
This implements CAPTION_URL without the needing of an image.