### PR TITLE
Render Basic CP Tabs Data Earlier

### DIFF
--- a/include/inc_front/content/cnt32.article.inc.php
+++ b/include/inc_front/content/cnt32.article.inc.php
@@ -41,6 +41,11 @@ if(empty($crow["acontent_template"]) && is_file(PHPWCMS_TEMPLATE.'inc_default/ta
 }
 
 if($tabs['template']) {
+    
+    $tabs['template'] = render_cnt_template($tabs['template'], 'ATTR_CLASS', html($crow['acontent_attr_class']));
+    $tabs['template'] = render_cnt_template($tabs['template'], 'ATTR_ID', html($crow['acontent_attr_id']));
+    $tabs['template'] = render_cnt_template($tabs['template'], 'TITLE', html_specialchars($crow['acontent_title']));
+    $tabs['template'] = render_cnt_template($tabs['template'], 'SUBTITLE', html_specialchars($crow['acontent_subtitle']));
 
     $tabs['entries']        = array();
 
@@ -160,10 +165,6 @@ if($tabs['template']) {
 
     }
 
-    $tabs['template'] = render_cnt_template($tabs['template'], 'ATTR_CLASS', html($crow['acontent_attr_class']));
-    $tabs['template'] = render_cnt_template($tabs['template'], 'ATTR_ID', html($crow['acontent_attr_id']));
-    $tabs['template'] = render_cnt_template($tabs['template'], 'TITLE', html_specialchars($crow['acontent_title']));
-    $tabs['template'] = render_cnt_template($tabs['template'], 'SUBTITLE', html_specialchars($crow['acontent_subtitle']));
     $tabs['template'] = render_cnt_template($tabs['template'], 'TABS_ENTRIES', count($tabs['entries']) ? implode('', $tabs['entries']) : '');
 
 } else {


### PR DESCRIPTION
When including an image/file field, {ATTR_CLASS} and {ATTR_ID} gets deleted by included file list CP. https://github.com/slackero/phpwcms/blob/0b0a88af72640f2d085d6fc4f0310332c89e922b/include/inc_front/content/cnt7.article.inc.php#L46 So CP basic tags should be replaced as soon as possible.