### PR TITLE
Fix Parsedown 2.0 method call

### DIFF
--- a/include/inc_front/content/cnt0.article.inc.php
+++ b/include/inc_front/content/cnt0.article.inc.php
@@ -47,7 +47,7 @@ switch($crow["acontent_form"]) {
 
     case 'markdown':
         init_markdown();
-        $crow['acontent_text'] = $phpwcms['parsedown_class']->text($crow['acontent_text']);
+        $crow['acontent_text'] = $phpwcms['parsedown_class']->toHtml($crow['acontent_text']);
         break;
 
     case 'textile':


### PR DESCRIPTION
Parsedown 2.0 is using `toHtml($markdown)` method: https://github.com/erusev/parsedown/pull/708#issuecomment-944799267

Sorry, just did this pull request online via github and didn't change all the other instances.